### PR TITLE
feat: 이메일 찾기, 비밀번호 초기화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	testImplementation 'org.springframework.security:spring-security-test'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/ormi/mogakcote/auth/dto/request/EmailWrapper.java
+++ b/src/main/java/com/ormi/mogakcote/auth/dto/request/EmailWrapper.java
@@ -1,0 +1,9 @@
+package com.ormi.mogakcote.auth.dto.request;
+
+import lombok.Data;
+
+@Data
+public class EmailWrapper {
+
+    private String email;
+}

--- a/src/main/java/com/ormi/mogakcote/auth/dto/request/FindEmailRequest.java
+++ b/src/main/java/com/ormi/mogakcote/auth/dto/request/FindEmailRequest.java
@@ -1,0 +1,14 @@
+package com.ormi.mogakcote.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class FindEmailRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String nickname;
+}

--- a/src/main/java/com/ormi/mogakcote/auth/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/ormi/mogakcote/auth/dto/request/PasswordResetRequest.java
@@ -1,0 +1,16 @@
+package com.ormi.mogakcote.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class PasswordResetRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/ormi/mogakcote/auth/dto/response/FindEmailResponse.java
+++ b/src/main/java/com/ormi/mogakcote/auth/dto/response/FindEmailResponse.java
@@ -1,0 +1,9 @@
+package com.ormi.mogakcote.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class FindEmailResponse {
+
+    private String email;
+}

--- a/src/main/java/com/ormi/mogakcote/auth/infrastructure/PasswordResetService.java
+++ b/src/main/java/com/ormi/mogakcote/auth/infrastructure/PasswordResetService.java
@@ -1,0 +1,54 @@
+package com.ormi.mogakcote.auth.infrastructure;
+
+import com.ormi.mogakcote.exception.dto.ErrorType;
+import com.ormi.mogakcote.exception.user.UserInvalidException;
+import com.ormi.mogakcote.redis.service.RedisService;
+import com.ormi.mogakcote.security.RandomStringGenerator;
+import com.ormi.mogakcote.user.application.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    @Value("${spring.security.user.password.reset.registerTimeoutSecond}")
+    private int registerTimeoutSecond;
+
+    private final RedisService<String> redisService;
+    private final UserService userService;
+
+    public String register(String email) {
+        if (!userService.existsByEmail(email)) {
+            throw new UserInvalidException(ErrorType.USER_NOT_FOUND_ERROR);
+        }
+
+        String key = getKey(email);
+        String code = RandomStringGenerator.generateRandomString(8);
+        redisService.set(key, code, registerTimeoutSecond);
+
+        return code;
+    }
+
+    public String reset(String email, String code) {
+        if (code == null) {
+            throw new IllegalArgumentException();
+        }
+
+        String key = getKey(email);
+        String value = redisService.getValue(key);
+        if (!code.equals(value)) {
+            throw new UserInvalidException(ErrorType.RESET_PASSWORD_CODE_NOT_MATCH_ERROR);
+        }
+
+        redisService.delete(key);
+        String newPassword = RandomStringGenerator.generateRandomString(24);
+        userService.updatePassword(email, newPassword);
+        return newPassword;
+    }
+
+    private String getKey(String email) {
+        return "Preset_" + email;
+    }
+}

--- a/src/main/java/com/ormi/mogakcote/email/service/EmailService.java
+++ b/src/main/java/com/ormi/mogakcote/email/service/EmailService.java
@@ -1,0 +1,27 @@
+package com.ormi.mogakcote.email.service;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @SneakyThrows
+    public void send(String from, String to, String subject, String content, boolean isHtml) {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+        helper.setFrom(from);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        helper.setText(content, isHtml);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/ormi/mogakcote/exception/dto/ErrorType.java
+++ b/src/main/java/com/ormi/mogakcote/exception/dto/ErrorType.java
@@ -26,6 +26,7 @@ public enum ErrorType {
     USED_ACCESS_TOKEN_ERROR(HttpStatus.FORBIDDEN, "이미 사용된 엑세스 토큰입니다"),
     USED_REFRESH_TOKEN_ERROR(HttpStatus.FORBIDDEN, "이미 사용된 리프레시 토큰입니다"),
     REFRESH_ACCESS_TOKEN_NOT_MATCH_ERROR(HttpStatus.FORBIDDEN, "엑세스 토큰이 일치하지 않습니다"),
+    RESET_PASSWORD_CODE_NOT_MATCH_ERROR(HttpStatus.BAD_REQUEST, "초기화 코드가 일치하지 않습니다"),
 
     // user 예외
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다");

--- a/src/main/java/com/ormi/mogakcote/user/application/UserService.java
+++ b/src/main/java/com/ormi/mogakcote/user/application/UserService.java
@@ -23,4 +23,22 @@ public class UserService {
     public User getByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new UserInvalidException(ErrorType.USER_NOT_FOUND_ERROR));
     }
+
+    @Transactional(readOnly = true)
+    public String getEmailByNameAndNickname(String name, String nickname) {
+        return userRepository.findEmailByNameAndNickname(name, nickname).orElseThrow(() -> new UserInvalidException(ErrorType.USER_NOT_FOUND_ERROR));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public void updatePassword(String email, String newPassword) {
+        int result = userRepository.updatePasswordByEmail(email, newPassword);
+        if (result <= 0) {
+            throw new UserInvalidException(ErrorType.USER_NOT_FOUND_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/ormi/mogakcote/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/ormi/mogakcote/user/infrastructure/UserRepository.java
@@ -2,7 +2,9 @@ package com.ormi.mogakcote.user.infrastructure;
 
 import com.ormi.mogakcote.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,4 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.email FROM User u WHERE u.email = :email AND u.nickname = :nickname")
     Optional<String> findEmailByNameAndNickname(String email, String nickname);
+
+    @Transactional
+    @Modifying
+    @Query("update User u set u.password = ?2 where u.email = ?1")
+    int updatePasswordByEmail(@NonNull String email, @NonNull String password);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -16,6 +16,8 @@ spring:
     user:
       password:
         secretKey: "secretKeysecretKeysecretKeysecretKey"
+        reset:
+          registerTimeoutSecond: 1800
 
   datasource:
     url: jdbc:mysql://localhost:3306/mogakcote

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -12,6 +12,19 @@ spring:
       static-locations: classpath:/static/
   application:
     name: mogak-codingtest
+  mail:
+    host: ${mail.host}
+    port: ${mail.port}
+    username: ${mail.username}
+    password: ${mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+          starttls:
+            enable: true
 
   jpa:
     open-in-view: true


### PR DESCRIPTION
## 🚀 연관된 이슈

- resolve: #32

## ✨ 작업 내용

- 이메일 찾기
- 비밀번호 초기화 요청 시 해당 이메일로 초기화 코드, 이메일이 담긴 form 메일 발송. 버튼 클릭 시 초기화 및 메일로 초기화된 비밀번호 발송

## 💬 리뷰 요구사항

- 이메일 발송 테스트 시 smtp 환경변수 설정 필요
![스크린샷 2024-08-30 143540](https://github.com/user-attachments/assets/b35116f0-0df7-42bf-ac23-fb89e066d09b)
